### PR TITLE
Should fix travis erroring on staging builds

### DIFF
--- a/scripts/staging-deploy.sh
+++ b/scripts/staging-deploy.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 echo "Building sources"
+cd source/ 
 npm run build
 
 echo "Deploying to staging server with Surge"
-npx surge -p docs -d https://revela.surge.sh
+npx surge -p ../docs -d https://revela.surge.sh


### PR DESCRIPTION
#6 forgot to change directories before executing the build script, as a result `package.json` couldn't be found, and `npm run build` is then undefined. This should fix that. 